### PR TITLE
fix(ci): gate pywin32 to win32 platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ plotly==6.7.0
 requests==2.34.2
 
 # --- Windows integration (PyInstaller builds, win shell) ---
-pywin32==308
+pywin32==308; sys_platform == "win32"


### PR DESCRIPTION
## Problem
After the UTF-16→UTF-8 encoding fix (PR #6), CI still failed at **Install dependencies**:

```
ERROR: Could not find a version that satisfies the requirement pywin32==308 (from versions: none)
ERROR: No matching distribution found for pywin32==308
```

`pywin32` is Windows-only and has no Linux wheels, so `pip install -r requirements.txt` aborts on the ubuntu runner before tests run.

## Fix
Add an environment marker so pywin32 installs on Windows only:

```
pywin32==308; sys_platform == "win32"
```

Linux CI skips it; Windows dev installs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)